### PR TITLE
Try to recover from failed init by deinit, retry

### DIFF
--- a/webcam.py
+++ b/webcam.py
@@ -23,16 +23,14 @@ def index(req, resp):
         led.on()
 
     # Camera resilience - if we fail to init try to deinit and init again
-    if (not camera.init()): #{
+    if (not camera.init()):
         camera.deinit()
         await asyncio.sleep(1)
         # If we fail to init, return a 503
-        if (not camera.init()): #{
+        if (not camera.init()):
             yield from picoweb.start_response(resp, status=503)
             yield from resp.awrite('ERROR: Failed to initialise camera\r\n\r\n')
             return
-        #}
-    #}
 
     # wait for sensor to start and focus before capturing image
     await asyncio.sleep(2)

--- a/webcam.py
+++ b/webcam.py
@@ -22,7 +22,17 @@ def index(req, resp):
     if flash == 'true':
         led.on()
 
-    camera.init()
+    # Camera resilience - if we fail to init try to deinit and init again
+    if (not camera.init()): #{
+        camera.deinit()
+        await asyncio.sleep(1)
+        # If we fail to init, return a 503
+        if (not camera.init()): #{
+            yield from picoweb.start_response(resp, status=503)
+            yield from resp.awrite('ERROR: Failed to initialise camera\r\n\r\n')
+            return
+        #}
+    #}
 
     # wait for sensor to start and focus before capturing image
     await asyncio.sleep(2)


### PR DESCRIPTION
This does a simple retry on fail of init() after first calling deinit(). This ensures we get another shot if the init() process failed because it was left in an unknown (or previously init()'d) state.

Fixes #2  

Signed-off-by: Krayon <krayon.git@qdnx.org>