### PR TITLE
Check capture return type for expected bytes

### DIFF
--- a/webcam.py
+++ b/webcam.py
@@ -31,7 +31,7 @@ def index(req, resp):
     led.off()
     camera.deinit()
 
-    if len(buf) > 0:
+    if type(buf) is bytes and len(buf) > 0:
         yield from picoweb.start_response(resp, "image/jpeg")
         yield from resp.awrite(buf)
     else:


### PR DESCRIPTION
This ensures that we only try to progress with delivering the image if we actually got a byte stream returned.

Fixes #4 

Signed-off-by: Krayon <krayon.git@qdnx.org>